### PR TITLE
Addition of speed control to joystick launch.

### DIFF
--- a/raptor_dbw_joystick/include/raptor_dbw_joystick/raptor_dbw_joystick.hpp
+++ b/raptor_dbw_joystick/include/raptor_dbw_joystick/raptor_dbw_joystick.hpp
@@ -74,8 +74,8 @@ typedef struct
   int turn_signal_cmd;
   bool joy_accelerator_pedal_valid;
   bool joy_brake_valid;
-//  float accel_limit;
-//  float decel_limit;
+  float accel_limit;
+  float decel_limit;
 } JoystickDataStruct;
 
 /** \brief Class for sending control commands to NE Raptor DBW with a joystick. */

--- a/raptor_dbw_joystick/include/raptor_dbw_joystick/raptor_dbw_joystick.hpp
+++ b/raptor_dbw_joystick/include/raptor_dbw_joystick/raptor_dbw_joystick.hpp
@@ -141,13 +141,13 @@ private:
   bool enable_;     // Use enable and disable buttons
   double svel_;     // Steering command speed
   float max_steer_angle_;  // Maximum steering angle allowed
-  bool raw_control;  // actuation type
-  double max_accelerator_pedal;  // maximum accelerator pedal allowed
-  double max_speed;  // maximum speed allowed
-//  double min_speed;
-  double max_accel;  // maximum acceleration
-  double max_decel;  // maximum deceleration
-  double speed_increment;  //
+  bool raw_control_;  // actuation type
+  double max_accelerator_pedal_;  // maximum accelerator pedal allowed
+  double max_speed_;  // maximum speed allowed
+//  double min_speed_;
+  double max_accel_;  // maximum acceleration
+  double max_decel_;  // maximum deceleration
+  double speed_increment_;  //
 
   // Variables
   rclcpp::TimerBase::SharedPtr timer_;
@@ -175,7 +175,7 @@ private:
     AXIS_STEER_1 = 0,             /**< Axis: steering wheel: - = clockwise, + = counterclockwise */
     AXIS_STEER_2 = 3,             /**< Axis: steering wheel: - = clockwise, + = counterclockwise */
     AXIS_TURN_SIG = 6,            /**< Axis: turn signals: - = right, + = left */
-    AXIS_SPEED_INCREMENT = 7      /**< Axis: speed_increment: - = down_arrow, + = up_ */
+    AXIS_SPEED_INCREMENT = 7,      /**< Axis: speed_increment: - = down_arrow, + = up_ */
     AXIS_COUNT = 8,               /**< Total number of axes (including unused) */
   };
 };

--- a/raptor_dbw_joystick/include/raptor_dbw_joystick/raptor_dbw_joystick.hpp
+++ b/raptor_dbw_joystick/include/raptor_dbw_joystick/raptor_dbw_joystick.hpp
@@ -74,6 +74,8 @@ typedef struct
   int turn_signal_cmd;
   bool joy_accelerator_pedal_valid;
   bool joy_brake_valid;
+//  float accel_limit;
+//  float decel_limit;
 } JoystickDataStruct;
 
 /** \brief Class for sending control commands to NE Raptor DBW with a joystick. */
@@ -86,13 +88,27 @@ public:
  * \param[in] enable Whether joystick node can control enable/disable
  * \param[in] svel Steering angle velocity, deg/s
  * \param[in] max_steer_angle Maximum steering angle allowed, deg
+ * \param[in] raw_control True: control pedal percentage, False: set speed for PID, bool
+ * \param[in] max_accelerator_pedal Maximum accelerator pedal value, 0 < max_accelerator_pedal < 100
+ * \param[in] max_speed Maximum car speed, +ve
+ * \param[in] min_speed Minimum car speed, -ve
+ * \param[in] max_accel Maximum longitudinal acceleration, +ve
+ * \param[in] max_decel Minimum longitudinal deceleration (for braking), +ve
+ * \param[in] speed_increment value to raise the speed per button press, +ve. Recommended: 0.44704 m/s (i.e 1 MPH)
  */
   explicit RaptorDbwJoystick(
     const rclcpp::NodeOptions & options,
     bool ignore,
     bool enable,
     double svel,
-    float max_steer_angle);
+    float max_steer_angle,
+    bool raw_control,
+    double max_accelerator_pedal,
+    double max_speed,
+//    double min_speed,
+    double max_accel,
+    double max_decel,
+    double speed_increment);
 
 private:
   rclcpp::Clock m_clock;
@@ -125,6 +141,13 @@ private:
   bool enable_;     // Use enable and disable buttons
   double svel_;     // Steering command speed
   float max_steer_angle_;  // Maximum steering angle allowed
+  bool raw_control;  // actuation type
+  double max_accelerator_pedal;  // maximum accelerator pedal allowed
+  double max_speed;  // maximum speed allowed
+//  double min_speed;
+  double max_accel;  // maximum acceleration
+  double max_decel;  // maximum deceleration
+  double speed_increment;  //
 
   // Variables
   rclcpp::TimerBase::SharedPtr timer_;
@@ -152,6 +175,7 @@ private:
     AXIS_STEER_1 = 0,             /**< Axis: steering wheel: - = clockwise, + = counterclockwise */
     AXIS_STEER_2 = 3,             /**< Axis: steering wheel: - = clockwise, + = counterclockwise */
     AXIS_TURN_SIG = 6,            /**< Axis: turn signals: - = right, + = left */
+    AXIS_SPEED_INCREMENT = 7      /**< Axis: speed_increment: - = down_arrow, + = up_ */
     AXIS_COUNT = 8,               /**< Total number of axes (including unused) */
   };
 };

--- a/raptor_dbw_joystick/launch/launch_params.yaml
+++ b/raptor_dbw_joystick/launch/launch_params.yaml
@@ -13,8 +13,17 @@
     max_steer_angle: 470.0
   # joy node
     device_id: 0
-#    device_name: "/dev/input/js0"
+    #device_name: "/dev/input/js0"
     deadzone: 0.5
     autorepeat_rate: 20.0
     sticky_buttons: false
     coalesce_interval_ms: 1
+  # speed control (closed loop) mode
+    raw_control: True
+    max_accelerator_pedal: 100.0
+    max_speed: 10.0
+    #min_speed: -10.0
+    max_accel: 3.0
+    max_decel: 3.0
+    speed_increment: 0.44704 # [m/s]. 0.44704 m/s = 1 MPH
+

--- a/raptor_dbw_joystick/src/raptor_dbw_joystick.cpp
+++ b/raptor_dbw_joystick/src/raptor_dbw_joystick.cpp
@@ -88,6 +88,10 @@ RaptorDbwJoystick::RaptorDbwJoystick(
     pub_disable_ = this->create_publisher<Empty>("disable", 1);
   }
 
+  if (max_accelerator_pedal > 100.0) {
+    max_accelerator_pedal = 100.0;
+  }
+
   timer_ = this->create_wall_timer(200ms, std::bind(&RaptorDbwJoystick::cmdCallback, this));
 }
 

--- a/raptor_dbw_joystick/src/raptor_dbw_joystick.cpp
+++ b/raptor_dbw_joystick/src/raptor_dbw_joystick.cpp
@@ -127,7 +127,7 @@ void RaptorDbwJoystick::cmdCallback()
         accelerator_pedal_msg.speed_cmd = data_.accelerator_pedal_joy; //
         accelerator_pedal_msg.road_slope = 0;  // todo: get from localization topic
         accelerator_pedal_msg.accel_limit = max_accel_;
-        accelerator_pedal_msg.control_type.value = raptor_dbw_msgs::ActuatorControlMode::CLOSED_LOOP_VEHICLE;
+        accelerator_pedal_msg.control_type.value = raptor_dbw_msgs::msg::ActuatorControlMode::CLOSED_LOOP_VEHICLE;
   }
 
   pub_accelerator_pedal_->publish(accelerator_pedal_msg);
@@ -144,7 +144,7 @@ void RaptorDbwJoystick::cmdCallback()
         brake_msg.control_type.value = raptor_dbw_msgs::msg::ActuatorControlMode::OPEN_LOOP;
   }
   else {
-        brake_msg.control_type.value = raptor_dbw_msgs::ActuatorControlMode::closed_loop_vehicle;
+        brake_msg.control_type.value = raptor_dbw_msgs::msg::ActuatorControlMode::CLOSED_LOOP_VEHICLE;
         brake_msg.decel_limit = max_decel_;
   }
 

--- a/raptor_dbw_joystick/src/raptor_dbw_joystick.cpp
+++ b/raptor_dbw_joystick/src/raptor_dbw_joystick.cpp
@@ -68,6 +68,8 @@ RaptorDbwJoystick::RaptorDbwJoystick(
   data_.turn_signal_cmd = TurnSignal::NONE;
   data_.joy_accelerator_pedal_valid = false;
   data_.joy_brake_valid = false;
+  data_.accel_limit = max_accel_;
+  data_.decel_limit = max_decel_;
 
   joy_.axes.resize(AXIS_COUNT, 0);
   joy_.buttons.resize(BTN_COUNT, 0);
@@ -126,7 +128,7 @@ void RaptorDbwJoystick::cmdCallback()
   else {
         accelerator_pedal_msg.speed_cmd = data_.accelerator_pedal_joy; //
         accelerator_pedal_msg.road_slope = 0;  // todo: get from localization topic
-        accelerator_pedal_msg.accel_limit = max_accel_;
+        accelerator_pedal_msg.accel_limit = data_.accel_limit;
         accelerator_pedal_msg.control_type.value = raptor_dbw_msgs::msg::ActuatorControlMode::CLOSED_LOOP_VEHICLE;
   }
 
@@ -145,7 +147,7 @@ void RaptorDbwJoystick::cmdCallback()
   }
   else {
         brake_msg.control_type.value = raptor_dbw_msgs::msg::ActuatorControlMode::CLOSED_LOOP_VEHICLE;
-        brake_msg.decel_limit = max_decel_;
+        brake_msg.decel_limit = data_.decel_limit;
   }
 
   pub_brake_->publish(brake_msg);
@@ -213,6 +215,8 @@ void RaptorDbwJoystick::recvJoy(const Joy::SharedPtr msg)
     data_.joy_brake_valid = true;
   }
 
+  data_.accel_limit = max_accel_;
+  data_.decel_limit = max_decel_;
   // Accelerator pedal
   if (data_.joy_accelerator_pedal_valid) {
     if (raw_control_) {
@@ -220,7 +224,8 @@ void RaptorDbwJoystick::recvJoy(const Joy::SharedPtr msg)
     }
     else {
         if (msg->axes[AXIS_ACCELERATOR_PEDAL] < 0.0) {
-            data_.accel_decel_limits = 0;
+            data_.accel_limit = 0;
+            data_.decel_limit = 0;
         }
     }
   }

--- a/raptor_dbw_joystick/src/raptor_dbw_joystick_node.cpp
+++ b/raptor_dbw_joystick/src/raptor_dbw_joystick_node.cpp
@@ -44,10 +44,27 @@ int main(int argc, char ** argv)
   temp->declare_parameter("svel", rclcpp::PARAMETER_DOUBLE);
   temp->declare_parameter("max_steer_angle", rclcpp::PARAMETER_DOUBLE);
 
+  // parameters to setup speed or raw control
+  temp->declare_parameter("raw_control", rclcpp::PARAMETER_BOOL);  // True: open_loop or raw, False:  closed_loop or speed
+  temp->declare_parameter("max_accelerator_pedal", rclcpp::PARAMETER_DOUBLE);  // for raw mode
+  temp->declare_parameter("max_speed", rclcpp::PARAMETER_DOUBLE);  // for speed mode
+//  temp->declare_parameter("min_speed", rclcpp::PARAMETER_DOUBLE);  // for speed mode
+  temp->declare_parameter("max_accel", rclcpp::PARAMETER_DOUBLE);  // for speed mode
+  temp->declare_parameter("max_decel", rclcpp::PARAMETER_DOUBLE);  // for speed mode
+  temp->declare_parameter("speed_increment", rclcpp::PARAMETER_DOUBLE);  // for speed mode
+
   bool n_ignore = temp->get_parameter("ignore").as_bool();
   bool n_enable = temp->get_parameter("enable").as_bool();
   double n_svel = temp->get_parameter("svel").as_double();
   float n_max_steer_angle = temp->get_parameter("max_steer_angle").as_double();
+  // parameters to setup speed or raw control
+  bool n_raw_control = temp->get_parameter("raw_control").as_bool();
+  float n_max_accelerator_pedal = temp->get_parameter("max_accelerator_pedal").as_double();
+  float n_max_speed = temp->get_parameter("max_speed").as_double();
+//  float n_min_speed = temp->get_parameter("min_speed").as_double();
+  float n_max_accel = temp->get_parameter("max_accel").as_double();
+  float n_max_decel = temp->get_parameter("max_decel").as_double();
+  float n_speed_increment = temp->get_parameter("speed_increment").as_double();
 
   // Create RaptorDbwJoystick class
   auto node = std::make_shared<raptor_dbw_joystick::RaptorDbwJoystick>(
@@ -55,7 +72,14 @@ int main(int argc, char ** argv)
     n_ignore,
     n_enable,
     n_svel,
-    n_max_steer_angle
+    n_max_steer_angle,
+    n_raw_control,
+    n_max_accelerator_pedal,
+    n_max_speed,
+//    n_min_speed,
+    n_max_accel,
+    n_max_decel,
+    n_speed_increment
   );
 
   exec.add_node(node->get_node_base_interface());


### PR DESCRIPTION
With this addition the joystick demo can now either be run in raw control mode, i.e controlling the percentage of pedal actuation or speed control mode, i.e setting a reference speed (by using the up and down arrow keys). Also set up acceleration pedal limits for safety as well as maximum (and minimum) longitudinal velocity, maximum acceleration and maximum deceleration.